### PR TITLE
Rework GitHub Pages style and expand vignettes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,5 @@
 ^\.Rproj\.user$
 ^LICENSE\.md$
 ^\.github$
+^_pkgdown\.yml$
+^pkgdown$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Date: 2026-06-26
 Authors@R: person("Konstantin", "Lang", , "konstantin.lang1@bayer.com", role = c("aut", "cre"))
 Description: R functions to compute Bland-Altman statistics and to visualize those statistics.
 License: file LICENSE
-URL: https://github.com/KonstantinLang/ggBA
+URL: https://github.com/KonstantinLang/ggBA, https://konstantinlang.github.io/ggBA/
 Depends:
     R (>= 4.1)
 Imports: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,10 @@
-# BAplot 0.3.0
+# ggBA 0.3.0
 
 * Added `transform` parameter to `ba_stat()` and `ba_plot()`, supporting
   `"identity"` (default), `"log"`, and `"logit"` transformations; both
   functions now delegate mean/difference computation to `ba_mean_diff()`.
 
-# BAplot 0.2.0
+# ggBA 0.2.0
 
 * Added `ba_mean_diff()`: helper function to compute mean and difference (or
   ratio) of two variables with optional `"identity"`, `"log"`, or `"logit"`
@@ -15,7 +15,7 @@
 * Added **pkgdown** site workflow.
 * Updated Roxygen documentation throughout.
 
-# BAplot 0.1.0
+# ggBA 0.1.0
 
 * Initial release.
 * `ba_stat()`: compute Bland-Altman statistics (bias, limits of agreement, and

--- a/README.md
+++ b/README.md
@@ -5,46 +5,56 @@
   [![](https://img.shields.io/github/last-commit/KonstantinLang/ggBA.svg)](https://github.com/KonstantinLang/ggBA/commits/main)
 <!-- badges: end -->
 
-## Bland-Altman
+## ggBA
 
-A Bland-Altman plot is a method of data plotting used in analyzing the agreement between two different methods. It was popularised in medical statistics by J. Martin Bland and Douglas G. Altman. [[1]](#r1) [[2]](#r2)
+**ggBA** helps you compute and visualize Bland-Altman agreement statistics with a tidy, ggplot2-friendly workflow.
 
-For more details see https://en.wikipedia.org/wiki/Bland%E2%80%93Altman_plot
+It supports identity, log, and logit scales so you can analyze absolute differences, ratios, or proportion-scale agreement in a consistent API.
 
-This package provides functions to plot Bland-Altman statistics based on {[ggplot2](https://github.com/tidyverse/ggplot2)} functionality.
+## Website and guides
+
+Package site: <https://konstantinlang.github.io/ggBA/>
+
+Included vignettes:
+
+1. `getting_started`: first analysis in a few steps
+1. `compare_methods`: side-by-side comparisons across scales
+1. `grouped_analysis`: stratified analysis and faceted visualization
 
 ## Installation
 
-Make sure {remotes} is installed:
+Install the development version from GitHub:
 
 ```r
-install.packages(c("remotes"))
-```
-
-Install source package from this repo. 3<sup>rd</sup>-party packages required or suggested by {ggBA} will be installed and/or upgraded automatically.
-
-```r
+install.packages("remotes")
 remotes::install_github("KonstantinLang/ggBA")
 ```
 
-## CRAN pre-submission check
+## Quick example
 
-For a full local CRAN-style check (including manual/PDF checks), install system tools first:
+```r
+library(tidyr)
+library(ggBA)
 
-- `pdflatex` (e.g. via TeX Live/TinyTeX)
-- `qpdf`
-- `tidy` (optional, for HTML validation notes)
+tbl <- temperature |>
+  pivot_wider(names_from = method, values_from = temperature)
 
-Then run:
+ba_stat(tbl, infrared, rectal)
+ba_plot(tbl, infrared, rectal)
+```
+
+## Development checks
+
+For a full local CRAN-style check (including manual/PDF checks), install system tools first (`pdflatex`, `qpdf`, and optionally `tidy`), then run:
 
 ```sh
 R CMD build .
-R CMD check --as-cran BAplot_*.tar.gz
+R CMD check --as-cran ggBA_*.tar.gz
 ```
 
 ## Issue tracker
 
-Report bugs etc. at https://github.com/KonstantinLang/ggBA/issues.
+Report issues at <https://github.com/KonstantinLang/ggBA/issues>.
 
 ## References
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,59 @@
+url: https://konstantinlang.github.io/ggBA/
+template:
+  bootstrap: 5
+  bootswatch: flatly
+  bslib:
+    base_font: {google: "Inter"}
+    heading_font: {google: "Space Grotesk"}
+    code_font: {google: "JetBrains Mono"}
+
+home:
+  title: ggBA
+  description: Tidy Bland-Altman statistics and plotting with ggplot2.
+
+navbar:
+  structure:
+    left: [intro, reference, articles, news]
+    right: [github]
+  components:
+    intro:
+      text: Overview
+      href: index.html
+    reference:
+      text: Reference
+      href: reference/index.html
+    articles:
+      text: Guides
+      menu:
+      - text: Getting started
+        href: articles/getting_started.html
+      - text: Compare methods across scales
+        href: articles/compare_methods.html
+      - text: Grouped and stratified analysis
+        href: articles/grouped_analysis.html
+    news:
+      text: Changelog
+      href: news/index.html
+    github:
+      icon: fab fa-github fa-lg
+      href: https://github.com/KonstantinLang/ggBA
+      aria-label: GitHub repository
+
+reference:
+- title: Core analysis functions
+  contents:
+  - ba_mean_diff
+  - ba_stat
+  - ba_plot
+- title: Data
+  contents:
+  - temperature
+  - gen_temp_data
+
+articles:
+- title: Guides
+  navbar: Guides
+  contents:
+  - getting_started
+  - compare_methods
+  - grouped_analysis

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -1,0 +1,60 @@
+:root {
+  --ggba-accent: #2f6db5;
+  --ggba-accent-soft: #eef4fb;
+  --ggba-border: #d8e3f3;
+}
+
+body {
+  font-feature-settings: "ss01" 1, "cv03" 1;
+}
+
+.navbar {
+  border-bottom: 1px solid var(--ggba-border);
+  box-shadow: 0 1px 0 rgba(17, 24, 39, 0.04);
+}
+
+.navbar-brand {
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.template-home h1,
+.template-home h2,
+.template-home h3 {
+  letter-spacing: -0.01em;
+}
+
+.template-home .page-header {
+  border: 1px solid var(--ggba-border);
+  border-radius: 14px;
+  background: linear-gradient(145deg, #ffffff 0%, var(--ggba-accent-soft) 100%);
+  padding: 1.5rem;
+}
+
+.template-home .page-header p {
+  color: #3a4c66;
+  margin-bottom: 0;
+}
+
+.template-reference-index .ref-index th,
+.template-reference-index .ref-index td {
+  vertical-align: middle;
+}
+
+pre, code {
+  border-radius: 8px;
+}
+
+a {
+  text-underline-offset: 0.15em;
+}
+
+a:hover,
+a:focus {
+  color: var(--ggba-accent);
+}
+
+.btn-primary {
+  background-color: var(--ggba-accent);
+  border-color: var(--ggba-accent);
+}

--- a/vignettes/compare_methods.Rmd
+++ b/vignettes/compare_methods.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "compare methods"
+title: "Compare methods across analysis scales"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{compare methods}
+  %\VignetteIndexEntry{Compare methods across analysis scales}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -14,83 +14,69 @@ knitr::opts_chunk$set(
 )
 ```
 
-## Setup
-
-Load packages
+## Overview
 
 ```{r setup}
-library(tidyr)       # Tidy Messy Data
-# library(knitr)       # A General-Purpose Package for Dynamic Report Generation in R
-library(kableExtra)  # Construct Complex Table with 'kable' and Pipe Syntax
-
+library(dplyr)
+library(knitr)
+library(tidyr)
 library(ggBA)
 ```
 
-Set options
+This vignette compares the same two measurement methods under three transformations:
 
-```{r options}
-options(
-  kable_styling_bootstrap_options = c("hover", "striped"),
-  kable_styling_full_width = FALSE,
-  kable_styling_position = "left"
-)
-```
+1. `identity`: absolute differences on the original scale
+1. `log`: ratio-focused agreement
+1. `logit`: agreement for proportion-scale measurements
 
-
-## Data
-
-Prepare data: create columns for every method of measuring temperature.
+## Prepare paired data
 
 ```{r dataprep}
-tbl <- 
-  temperature |> 
+tbl <- temperature |>
   pivot_wider(names_from = method, values_from = temperature)
 ```
 
-## Compare methods (identity scale)
+The `temperature` dataset is stored in long format (`method` + `temperature` values).
+For pairwise comparisons, we first create one column per method (`infrared`, `rectal`).
 
-### Compute statistics
+## Identity scale (default)
+
+Use this when absolute differences are directly interpretable.
 
 ```{r simple_stats_table}
-ba_stat(data = tbl, var1 = infrared, var2 = rectal) |> 
-  pivot_wider(names_from = parameter, values_from = value) |> 
-  kable() |> 
-  kable_styling()
+ba_stat(data = tbl, var1 = infrared, var2 = rectal) |>
+  pivot_wider(names_from = parameter, values_from = value) |>
+  kable(digits = 3)
 ```
-
-### Visualize comparison
 
 ```{r simple_baplot}
 ba_plot(data = tbl, var1 = infrared, var2 = rectal)
 ```
 
-## Compare methods (log scale)
+## Log scale
 
-When measurements span several orders of magnitude, or when proportional
-differences are more meaningful than absolute differences, a log-scale
-Bland-Altman analysis is appropriate.  On the log scale the "difference"
-becomes `log(var1) - log(var2) = log(var1 / var2)`, and the bias
-represents a systematic ratio between the two methods.
+Use a log transform when proportional differences are more meaningful than
+absolute ones. On this scale:
+
+`log(var1) - log(var2) = log(var1 / var2)`
 
 ```{r log_stats_table}
-ba_stat(data = tbl, var1 = infrared, var2 = rectal, transform = "log") |> 
-  pivot_wider(names_from = parameter, values_from = value) |> 
-  kable(digits = 4) |> 
-  kable_styling()
+log_stats <- ba_stat(data = tbl, var1 = infrared, var2 = rectal, transform = "log")
+
+log_stats |>
+  pivot_wider(names_from = parameter, values_from = value) |>
+  kable(digits = 4)
 ```
 
-The bias on the log scale can be back-transformed to a ratio:
+The bias can be back-transformed to a ratio:
 `exp(bias)` gives the geometric mean ratio (infrared / rectal).
 
 ```{r log_bias_backtransform}
-log_stats <- ba_stat(data = tbl, var1 = infrared, var2 = rectal, transform = "log")
-log_bias  <- log_stats$value[log_stats$parameter == "bias"]
+log_bias <- log_stats |>
+  filter(parameter == "bias") |>
+  pull(value)
 cat("Geometric mean ratio (infrared / rectal):", round(exp(log_bias), 4), "\n")
 ```
-
-Visualize the log-scale Bland-Altman plot.  The y-axis shows
-`log(infrared / rectal)` and the x-axis shows the mean of the log-transformed
-values.
 
 ```{r log_baplot}
 ba_plot(
@@ -103,11 +89,10 @@ ba_plot(
 )
 ```
 
-## Compare proportions (logit scale)
+## Logit scale for proportions
 
-For measurements expressed as proportions (values in (0, 1)), a logit
-transformation stabilises variance and yields differences on an
-approximately Normal scale.
+For values restricted to `(0, 1)`, a logit transform often gives better
+variance behavior and an approximately Normal difference scale.
 
 ```{r logit_example}
 set.seed(42)
@@ -116,10 +101,11 @@ prop_tbl <- data.frame(
   p2 = runif(60, 0.05, 0.95)
 )
 
-ba_stat(data = prop_tbl, var1 = p1, var2 = p2, transform = "logit") |>
+logit_stats <- ba_stat(data = prop_tbl, var1 = p1, var2 = p2, transform = "logit")
+
+logit_stats |>
   pivot_wider(names_from = parameter, values_from = value) |>
-  kable(digits = 3) |>
-  kable_styling()
+  kable(digits = 3)
 ```
 
 ```{r logit_baplot}

--- a/vignettes/getting_started.Rmd
+++ b/vignettes/getting_started.Rmd
@@ -1,0 +1,75 @@
+---
+title: "Getting started with ggBA"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Getting started with ggBA}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+## What this guide covers
+
+This short guide walks through a complete Bland-Altman workflow:
+
+1. reshape long-format data into paired columns
+1. compute agreement statistics
+1. visualize agreement with one line of plotting code
+
+```{r setup}
+library(knitr)
+library(tidyr)
+library(ggBA)
+```
+
+## 1) Prepare paired measurements
+
+`temperature` contains one row per animal, visit, and measurement method.  
+To compare two methods directly, pivot to wide format.
+
+```{r prep-data}
+tbl <- temperature |>
+  pivot_wider(names_from = method, values_from = temperature)
+
+head(tbl, 6) |>
+  kable(digits = 2)
+```
+
+## 2) Compute Bland-Altman statistics
+
+```{r compute-stats}
+stats_tbl <- ba_stat(tbl, infrared, rectal)
+stats_tbl |>
+  tidyr::pivot_wider(names_from = parameter, values_from = value) |>
+  kable(digits = 3)
+```
+
+The most commonly interpreted quantities are:
+
+1. `bias`: average difference between methods
+1. `lloa` and `uloa`: lower and upper limits of agreement
+
+## 3) Plot agreement
+
+```{r make-plot}
+ba_plot(
+  data = tbl,
+  var1 = infrared,
+  var2 = rectal,
+  title = "Infrared vs rectal temperature",
+  caption = "Lines show bias and limits of agreement with confidence bounds."
+)
+```
+
+## Next steps
+
+After this baseline workflow, explore:
+
+1. transformed analyses (`transform = "log"` or `"logit"`)
+1. grouped analyses via `group =` in `ba_stat()` and `ba_plot()`

--- a/vignettes/grouped_analysis.Rmd
+++ b/vignettes/grouped_analysis.Rmd
@@ -1,0 +1,86 @@
+---
+title: "Grouped and stratified Bland-Altman analysis"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Grouped and stratified Bland-Altman analysis}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+## Why group the analysis?
+
+Agreement can differ across biological or operational subgroups.  
+`ggBA` supports grouped summaries and faceted plots to inspect those patterns.
+
+```{r setup}
+library(dplyr)
+library(knitr)
+library(tidyr)
+library(ggBA)
+```
+
+## Build paired data once
+
+```{r prep-data}
+tbl <- temperature |>
+  pivot_wider(names_from = method, values_from = temperature)
+```
+
+## Grouped statistics by treatment
+
+```{r grouped-stats}
+treatment_stats <- ba_stat(
+  data = tbl,
+  var1 = infrared,
+  var2 = rectal,
+  group = treatment
+)
+
+treatment_stats |>
+  filter(parameter %in% c("bias", "lloa", "uloa")) |>
+  tidyr::pivot_wider(names_from = parameter, values_from = value) |>
+  arrange(treatment) |>
+  kable(digits = 3)
+```
+
+This table highlights subgroup-level shifts in bias and spread.
+
+## Faceted Bland-Altman plots
+
+```{r grouped-plot}
+ba_plot(
+  data = tbl,
+  var1 = infrared,
+  var2 = rectal,
+  group = treatment,
+  colour = visit,
+  title = "Agreement by treatment group",
+  caption = "Each panel has treatment-specific Bland-Altman summary lines."
+)
+```
+
+## Optional: log-scale grouped analysis
+
+If multiplicative differences are more relevant, add `transform = "log"`:
+
+```{r grouped-log}
+ba_stat(
+  data = tbl,
+  var1 = infrared,
+  var2 = rectal,
+  group = treatment,
+  transform = "log"
+) |>
+  filter(parameter == "bias") |>
+  mutate(geom_ratio = exp(value)) |>
+  select(treatment, geom_ratio) |>
+  arrange(treatment) |>
+  kable(digits = 3)
+```


### PR DESCRIPTION
Summary: Added explicit pkgdown configuration and custom site styling, rewrote README wording, normalized BAplot naming in NEWS, revised compare_methods vignette, and added getting_started plus grouped_analysis vignettes. Note: Local pkgdown build is blocked in this environment by R shared-library ABI mismatch; GitHub Actions pkgdown workflow will validate and publish.